### PR TITLE
[Fix] 메인 페이지 무한 스크롤 버그 수정

### DIFF
--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -20,7 +20,7 @@ const categoriesList = [
 ];
 
 export default function WatchaMainPage() {
-  const { movies, loading, hasMore, loadMovies, loadNextPage } = useMovies();
+  const { movies, loading, hasMore, error, loadMovies, loadNextPage } = useMovies();
 
   const [activeCategories, setActiveCategories] = useState<string[]>([]);
   const [searchQuery, setSearchQuery] = useState('');
@@ -28,13 +28,11 @@ export default function WatchaMainPage() {
   const observerRef = useRef<IntersectionObserver | null>(null);
   const lastMovieRef = useRef<HTMLDivElement | null>(null);
 
-  // 초기 로드
+  // 초기 로드 및 카테고리 변경
   useEffect(() => {
-    loadMovies(1, activeCategories);
-  }, [loadMovies, activeCategories]);
-
-  // 카테고리 변경
-  useEffect(() => {
+    if (process.env.NODE_ENV === 'development') {
+      console.log(`useEffect 실행 - 카테고리 변경: [${activeCategories.join(', ')}]`);
+    }
     loadMovies(1, activeCategories);
   }, [loadMovies, activeCategories]);
 
@@ -80,6 +78,13 @@ export default function WatchaMainPage() {
   const filteredMovies = searchQuery
     ? movies.filter((m) => m.title.toLowerCase().includes(searchQuery.toLowerCase()))
     : movies;
+
+  // 디버깅: 배열 크기 확인 (개발 환경에서만)
+  if (process.env.NODE_ENV === 'development') {
+    console.log(
+      `데이터 상태 - movies: ${movies.length}개, filteredMovies: ${filteredMovies.length}개, searchQuery: "${searchQuery}"`,
+    );
+  }
 
   return (
     <div
@@ -138,12 +143,13 @@ export default function WatchaMainPage() {
             marginBottom: '40px',
           }}
         >
-          {filteredMovies.map((movie, index) => {
-            const isLastItem = index === filteredMovies.length - 1;
+          {filteredMovies.map((movie) => {
+            // 모든 상황에서 무한 스크롤 동작 - movies 배열의 마지막 아이템 기준
+            const isLastItemInMovies = movies[movies.length - 1]?._id === movie._id;
             return (
               <MovieCard
                 key={movie._id}
-                ref={isLastItem ? lastMovieRef : null}
+                ref={isLastItemInMovies ? lastMovieRef : null}
                 _id={movie._id}
                 title={movie.title}
                 categories={movie.categories}
@@ -155,6 +161,7 @@ export default function WatchaMainPage() {
                 trailer_url={movie.trailer_url}
                 description={movie.description}
                 director={movie.director}
+                is_adult_content={movie.is_adult_content}
                 poster_url={movie.poster_url}
                 age_rating={movie.age_rating}
                 created_at={movie.created_at}
@@ -165,6 +172,36 @@ export default function WatchaMainPage() {
           })}
         </div>
 
+        {error && (
+          <div
+            style={{
+              textAlign: 'center',
+              padding: '60px 20px',
+              color: '#ff6b6b',
+              background: 'rgba(255, 107, 107, 0.1)',
+              borderRadius: '8px',
+              marginBottom: '20px',
+            }}
+          >
+            <div style={{ fontSize: '18px', marginBottom: '10px' }}>⚠️ 오류 발생</div>
+            <div style={{ fontSize: '14px', marginBottom: '20px' }}>{error}</div>
+            <button
+              onClick={() => loadMovies(1, activeCategories)}
+              style={{
+                background: '#ff6b6b',
+                color: 'white',
+                border: 'none',
+                padding: '10px 20px',
+                borderRadius: '4px',
+                cursor: 'pointer',
+                fontSize: '14px',
+              }}
+            >
+              다시 시도
+            </button>
+          </div>
+        )}
+
         {loading && (
           <div style={{ textAlign: 'center', padding: '60px', color: '#999' }}>
             영화를 불러오는 중...
@@ -172,7 +209,9 @@ export default function WatchaMainPage() {
         )}
         {!hasMore && filteredMovies.length > 0 && (
           <div style={{ textAlign: 'center', padding: '40px', color: '#666' }}>
-            모든 영화를 불러왔습니다
+            {activeCategories.length === 0
+              ? '모든 영화를 불러왔습니다'
+              : `${activeCategories.join(', ')} 카테고리의 모든 영화를 불러왔습니다`}
           </div>
         )}
         {filteredMovies.length === 0 && !loading && (

--- a/src/components/common/WatchaStorybook/WatchaStorybook.tsx
+++ b/src/components/common/WatchaStorybook/WatchaStorybook.tsx
@@ -172,11 +172,12 @@ export default function WatchaStorybook() {
                 categories={['액션', '어드벤처']}
                 running_time={120}
                 release_date="2010-01-01"
-                rating_total={props.rating}
+                rating_total={props.rating * 1234}
                 review_count={1234}
                 audience={500000}
                 description="쥬라기 월드 설명"
-                director="콜린 트레보로우"
+                director={{ name: '콜린 트레보로우' }}
+                is_adult_content={false}
                 poster_url=""
                 age_rating="12"
               />
@@ -186,11 +187,12 @@ export default function WatchaStorybook() {
                 categories={['공포', '스릴러']}
                 running_time={113}
                 release_date="2010-01-01"
-                rating_total={props.rating}
+                rating_total={props.rating * 987}
                 review_count={987}
                 audience={300000}
                 description="28일 후 설명"
-                director="대니 보일"
+                director={{ name: '대니 보일' }}
+                is_adult_content={true}
                 poster_url=""
                 age_rating="18"
               />
@@ -200,11 +202,12 @@ export default function WatchaStorybook() {
                 categories={['SF', '액션']}
                 running_time={180}
                 release_date="2010-01-01"
-                rating_total={4.5}
+                rating_total={4.5 * 2500}
                 review_count={2500}
                 audience={1000000}
                 description="아바타 3 설명"
-                director="제임스 카메론"
+                director={{ name: '제임스 카메론' }}
+                is_adult_content={false}
                 poster_url=""
                 age_rating="12"
               />
@@ -214,11 +217,12 @@ export default function WatchaStorybook() {
                 categories={['SF', '드라마']}
                 running_time={155}
                 release_date="2010-01-01"
-                rating_total={props.rating}
+                rating_total={props.rating * 1800}
                 review_count={1800}
                 audience={800000}
                 description="듄: 파트3 설명"
-                director="드니 빌뇌브"
+                director={{ name: '드니 빌뇌브' }}
+                is_adult_content={false}
                 poster_url=""
                 age_rating="15"
               />
@@ -355,11 +359,12 @@ export default function WatchaStorybook() {
                     categories={['액션']}
                     running_time={120}
                     release_date={`${movie.year || 2012}-01-01`}
-                    rating_total={movie.rating || 4.0}
+                    rating_total={(movie.rating || 4.0) * 1000}
                     review_count={1000}
                     audience={500000}
                     description={'영화 설명'}
-                    director={'감독'}
+                    director={{ name: '감독' }}
+                    is_adult_content={false}
                     poster_url={''}
                     age_rating={'12'}
                     {...movie}

--- a/src/components/movie/MovieCard/MovieCard.stories.tsx
+++ b/src/components/movie/MovieCard/MovieCard.stories.tsx
@@ -23,12 +23,86 @@ export const Default: Story = {
     categories: ['액션', '어드벤처'],
     running_time: 124,
     release_date: '2024-06-15',
-    rating_total: 3.5,
+    rating_total: 8610, // 3.5 * 2456 (평균 평점 * 리뷰 수)
     review_count: 2456,
     audience: 850000,
     description: '공룡들이 세상을 지배하는 판타지 어드벤처',
-    director: '콜린 트레보로우',
+    director: { name: '콜린 트레보로우' },
+    is_adult_content: false,
     poster_url: '',
     age_rating: '12',
+  },
+};
+
+export const HighRated: Story = {
+  args: {
+    _id: '2',
+    title: '기생충',
+    categories: ['드라마', '스릴러'],
+    running_time: 132,
+    release_date: '2019-05-30',
+    rating_total: 22500, // 4.5 * 5000
+    review_count: 5000,
+    audience: 10085374,
+    description: '가족의 꿈을 이루기 위한 기생충의 이야기',
+    director: { name: '봉준호' },
+    is_adult_content: false,
+    poster_url: '',
+    age_rating: '15',
+  },
+};
+
+export const AdultContent: Story = {
+  args: {
+    _id: '3',
+    title: '덱스터',
+    categories: ['스릴러', '범죄'],
+    running_time: 108,
+    release_date: '2023-03-15',
+    rating_total: 7200, // 4.0 * 1800
+    review_count: 1800,
+    audience: 450000,
+    description: '연쇄살인마의 심리를 다룬 성인 스릴러',
+    director: { name: '클라이드 필립스' },
+    is_adult_content: true,
+    poster_url: '',
+    age_rating: '18',
+  },
+};
+
+export const WithRank: Story = {
+  args: {
+    _id: '4',
+    title: '어벤져스: 엔드게임',
+    categories: ['액션', 'SF'],
+    running_time: 181,
+    release_date: '2019-04-24',
+    rating_total: 20000, // 4.0 * 5000
+    review_count: 5000,
+    audience: 13934592,
+    description: '마블 유니버스의 대서사시',
+    director: { name: '루소 형제' },
+    is_adult_content: false,
+    poster_url: '',
+    age_rating: '12',
+    rank: 1,
+  },
+};
+
+export const LowRated: Story = {
+  args: {
+    _id: '5',
+    title: '저예산 B급 영화',
+    categories: ['코미디'],
+    running_time: 85,
+    release_date: '2023-01-10',
+    rating_total: 1000, // 2.0 * 500
+    review_count: 500,
+    audience: 15000,
+    description: '예산이 부족했지만 정성이 가득한 영화',
+    director: { name: '무명 감독' },
+    is_adult_content: false,
+    poster_url: '',
+    age_rating: 'ALL',
   },
 };

--- a/src/components/movie/MovieCard/MovieCard.tsx
+++ b/src/components/movie/MovieCard/MovieCard.tsx
@@ -18,7 +18,8 @@ export const MovieCard = forwardRef<HTMLDivElement, MovieCardProps>(
       audience: _audience = 0,
       trailer_url: _trailerUrl,
       description: _description = '',
-      director = '',
+      director = { name: '', profile_image: '' },
+      is_adult_content = false,
       poster_url,
       age_rating = 'ALL',
       created_at: _createdAt,
@@ -52,6 +53,16 @@ export const MovieCard = forwardRef<HTMLDivElement, MovieCardProps>(
       overflow: 'hidden',
     };
 
+    const blurOverlayStyle: React.CSSProperties = {
+      position: 'absolute',
+      top: 0,
+      left: 0,
+      right: 0,
+      bottom: 0,
+      backdropFilter: is_adult_content ? 'blur(8px)' : 'none',
+      zIndex: 1,
+    };
+
     const overlayStyle: React.CSSProperties = {
       position: 'absolute',
       top: 0,
@@ -64,6 +75,7 @@ export const MovieCard = forwardRef<HTMLDivElement, MovieCardProps>(
       justifyContent: 'flex-end',
       padding: watchaTokens.spacing.md,
       transition: 'background 0.3s ease',
+      zIndex: 2,
     };
 
     const adultBadgeStyle: React.CSSProperties = {
@@ -76,7 +88,7 @@ export const MovieCard = forwardRef<HTMLDivElement, MovieCardProps>(
       borderRadius: watchaTokens.borderRadius.sm,
       fontSize: watchaTokens.typography.fontSize.xs,
       fontWeight: watchaTokens.typography.fontWeight.bold,
-      zIndex: 2,
+      zIndex: 3,
       backdropFilter: 'blur(4px)',
     };
 
@@ -110,20 +122,25 @@ export const MovieCard = forwardRef<HTMLDivElement, MovieCardProps>(
       gap: '2px',
     };
 
-    // 평점: rating_total이 이미 평균 평점값
-    const calculatedRating = rating_total || 0;
+    // 평균 별점 계산: rating_total / review_count
+    const averageRating = review_count > 0 ? rating_total / review_count : 0;
+    // 0.5 단위로 반올림
+    const calculatedRating = Math.round(averageRating * 2) / 2;
 
     const renderStars = (ratingValue: number) => {
       const stars = [];
       const fullStars = Math.floor(ratingValue);
-      const hasHalfStar = ratingValue % 1 !== 0;
+      const hasHalfStar = ratingValue % 1 === 0.5;
 
       for (let i = 0; i < 5; i++) {
         if (i < fullStars) {
+          // 완전한 별
           stars.push('★');
         } else if (i === fullStars && hasHalfStar) {
-          stars.push('☆');
+          // 반 별 (유니코드 반별 문자 사용)
+          stars.push('⭐');
         } else {
+          // 빈 별
           stars.push('☆');
         }
       }
@@ -146,6 +163,7 @@ export const MovieCard = forwardRef<HTMLDivElement, MovieCardProps>(
         onClick={onClick}
       >
         <div style={imageContainerStyle}>
+          {is_adult_content && <div style={blurOverlayStyle}></div>}
           {rank && (
             <div
               style={{
@@ -159,7 +177,7 @@ export const MovieCard = forwardRef<HTMLDivElement, MovieCardProps>(
                 fontSize: '12px',
                 fontWeight: 'bold',
                 backdropFilter: 'blur(4px)',
-                zIndex: 1,
+                zIndex: 2,
               }}
             >
               #{rank}
@@ -177,7 +195,7 @@ export const MovieCard = forwardRef<HTMLDivElement, MovieCardProps>(
                 >
                   {title}
                 </div>
-                {director && (
+                {director?.name && (
                   <div
                     style={{
                       fontSize: watchaTokens.typography.fontSize.xs,
@@ -185,7 +203,7 @@ export const MovieCard = forwardRef<HTMLDivElement, MovieCardProps>(
                       marginTop: '2px',
                     }}
                   >
-                    감독: {director}
+                    감독: {director.name}
                   </div>
                 )}
                 <div
@@ -195,7 +213,7 @@ export const MovieCard = forwardRef<HTMLDivElement, MovieCardProps>(
                     marginTop: '4px',
                   }}
                 >
-                  평점 ★ {calculatedRating.toFixed(1)} ({review_count}명)
+                  평점 ★ {averageRating.toFixed(1)} ({review_count}명)
                 </div>
               </div>
             )}

--- a/src/hooks/movie/useMovies.ts
+++ b/src/hooks/movie/useMovies.ts
@@ -1,22 +1,54 @@
 'use client';
 import { useState, useCallback } from 'react';
 import { Movie } from '@/types/movie';
+import { MoviesApiResponse } from '@/types/api';
 import axios from 'axios';
 
-const API_BASE_URL = 'http://localhost:4000/api';
-const ITEMS_PER_PAGE = 20;
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:4000/api';
+const ITEMS_PER_PAGE = Number(process.env.NEXT_PUBLIC_ITEMS_PER_PAGE) || 20;
+
+// 영화 데이터 검증 함수
+const validateMovieData = (movie: any): movie is Movie => {
+  return (
+    typeof movie === 'object' &&
+    movie !== null &&
+    typeof movie._id === 'string' &&
+    typeof movie.title === 'string' &&
+    Array.isArray(movie.categories) &&
+    typeof movie.running_time === 'number' &&
+    typeof movie.release_date === 'string' &&
+    typeof movie.rating_total === 'number' &&
+    typeof movie.review_count === 'number' &&
+    typeof movie.audience === 'number' &&
+    typeof movie.description === 'string' &&
+    typeof movie.director === 'object' &&
+    movie.director !== null &&
+    typeof movie.director.name === 'string' &&
+    typeof movie.age_rating === 'string' &&
+    typeof movie.is_adult_content === 'boolean'
+  );
+};
 
 export function useMovies() {
   const [movies, setMovies] = useState<Movie[]>([]);
   const [loading, setLoading] = useState(false);
   const [page, setPage] = useState(1);
   const [hasMore, setHasMore] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  // 중복 요청 방지를 위한 ref
+  const loadingRef = useState({ isLoading: false })[0];
 
   const loadMovies = useCallback(
     async (pageNum: number = 1, categories: string[] = [], append: boolean = false) => {
-      if (loading) return;
+      // 이미 로딩 중이면 중복 요청 방지
+      if (loadingRef.isLoading) {
+        return;
+      }
 
+      loadingRef.isLoading = true;
       setLoading(true);
+      setError(null); // 새로운 요청 시 에러 초기화
 
       try {
         let url = `${API_BASE_URL}/movies?page=${pageNum}&limit=${ITEMS_PER_PAGE}`;
@@ -29,11 +61,36 @@ export function useMovies() {
           url += `&sort=popular`;
         }
 
-        console.log('API 호출 URL:', url);
-        const response = await axios.get(url);
+        const response = await axios.get<MoviesApiResponse | Movie[]>(url);
 
-        // API 응답 구조 확인
-        const newMovies: Movie[] = response.data.movies || response.data;
+        // API 응답 구조를 안정적으로 처리
+        let newMovies: Movie[] = [];
+
+        if (Array.isArray(response.data)) {
+          // 직접 배열로 반환되는 경우 (레거시 API)
+          newMovies = response.data;
+        } else if (
+          response.data &&
+          typeof response.data === 'object' &&
+          'movies' in response.data
+        ) {
+          // 객체 형태로 반환되는 경우 (새로운 API)
+          newMovies = response.data.movies || [];
+        } else {
+          throw new Error('API 응답 형식이 올바르지 않습니다.');
+        }
+
+        // 데이터 검증
+        const validMovies = newMovies.filter(validateMovieData);
+        if (validMovies.length !== newMovies.length) {
+          if (process.env.NODE_ENV === 'development') {
+            console.warn(
+              `${newMovies.length - validMovies.length}개의 잘못된 영화 데이터가 제외되었습니다.`,
+            );
+          }
+        }
+
+        newMovies = validMovies;
 
         // 카테고리가 없을 때 인기 순위 추가
         const moviesWithRank =
@@ -45,25 +102,56 @@ export function useMovies() {
             : newMovies;
 
         if (append) {
-          setMovies((prev) => [...prev, ...moviesWithRank]);
+          setMovies((prev) => {
+            // 기존 영화 ID들을 Set으로 관리하여 중복 확인
+            const existingIds = new Set(prev.map((movie) => movie._id));
+            const newUniqueMovies = moviesWithRank.filter((movie) => !existingIds.has(movie._id));
+
+            // 중복된 영화가 있으면 로그 출력 (개발 환경에서만)
+            if (process.env.NODE_ENV === 'development') {
+              const duplicateCount = moviesWithRank.length - newUniqueMovies.length;
+              if (duplicateCount > 0) {
+                console.warn(`${duplicateCount}개의 중복 영화가 제외되었습니다.`);
+              }
+            }
+
+            return [...prev, ...newUniqueMovies];
+          });
         } else {
           setMovies(moviesWithRank);
           setPage(1);
         }
 
-        setHasMore(newMovies.length >= ITEMS_PER_PAGE);
-      } catch (error) {
-        console.error('영화 로드 실패:', error);
-        if (axios.isAxiosError(error)) {
-          console.error('에러 상세:', error.response?.data || error.message);
-        } else {
-          console.error('에러 상세:', String(error));
+        // 서버에서 반환된 영화 수가 요청한 개수보다 적으면 더 이상 데이터 없음
+        setHasMore(newMovies.length === ITEMS_PER_PAGE);
+      } catch (err) {
+        if (process.env.NODE_ENV === 'development') {
+          console.error('영화 로드 실패:', err);
         }
+
+        let errorMessage = '영화를 불러오는 중 오류가 발생했습니다.';
+
+        if (axios.isAxiosError(err)) {
+          if (err.response?.status === 404) {
+            errorMessage = '요청한 페이지를 찾을 수 없습니다.';
+          } else if (err.response?.status === 500) {
+            errorMessage = '서버 오류가 발생했습니다. 잠시 후 다시 시도해주세요.';
+          } else if (err.code === 'NETWORK_ERROR') {
+            errorMessage = '네트워크 연결을 확인해주세요.';
+          } else if (err.response?.data?.message) {
+            errorMessage = err.response.data.message;
+          }
+        } else if (err instanceof Error) {
+          errorMessage = err.message;
+        }
+
+        setError(errorMessage);
       } finally {
+        loadingRef.isLoading = false;
         setLoading(false);
       }
     },
-    [loading],
+    [], // dependency 제거 - setState 함수들은 stable하므로
   );
 
   const loadNextPage = useCallback(
@@ -80,6 +168,7 @@ export function useMovies() {
     movies,
     loading,
     hasMore,
+    error,
     loadMovies,
     loadNextPage,
     setMovies,

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -1,0 +1,42 @@
+import { Movie } from './movie';
+
+// API 응답 기본 인터페이스
+export interface ApiResponse<T> {
+  success: boolean;
+  data: T;
+  message?: string;
+}
+
+// 영화 목록 API 응답
+export interface MoviesApiResponse {
+  movies: Movie[];
+  totalCount: number;
+  currentPage: number;
+  hasMore: boolean;
+}
+
+// 에러 응답
+export interface ErrorResponse {
+  success: false;
+  error: {
+    message: string;
+    code?: string;
+    details?: any;
+  };
+}
+
+// API 클라이언트 설정
+export interface ApiConfig {
+  baseURL: string;
+  timeout?: number;
+  headers?: Record<string, string>;
+}
+
+// 영화 검색 파라미터
+export interface MoviesQueryParams {
+  page?: number;
+  limit?: number;
+  categories?: string;
+  sort?: 'popular' | 'rating' | 'newest' | 'oldest';
+  search?: string;
+}

--- a/src/types/movie.ts
+++ b/src/types/movie.ts
@@ -1,6 +1,12 @@
 export interface Cast {
   name: string;
   role: string;
+  profile_image?: string;
+}
+
+export interface Director {
+  name: string;
+  profile_image?: string;
 }
 
 export interface Movie {
@@ -15,9 +21,10 @@ export interface Movie {
   trailer_url?: string;
   description: string;
   cast: Cast[];
-  director: string;
+  director: Director;
   poster_url?: string;
-  age_rating: string; // 시청 등급: ALL, 12, 15, 18 등
+  age_rating: string; // 시청 등급: ALL, 12, 15, 18, NR 등
+  is_adult_content: boolean; // 18등급 여부 (블러 효과용)
   created_at?: string;
   __v?: number;
   rank?: number;

--- a/src/types/movieCardProps.ts
+++ b/src/types/movieCardProps.ts
@@ -1,3 +1,5 @@
+import { Director } from './movie';
+
 export interface MovieCardProps {
   _id: string;
   title: string;
@@ -9,9 +11,10 @@ export interface MovieCardProps {
   audience: number;
   trailer_url?: string;
   description: string;
-  director: string;
+  director: Director;
   poster_url?: string;
-  age_rating: string; // 시청 등급: ALL, 12, 15, 18 등
+  age_rating: string; // 시청 등급: ALL, 12, 15, 18, NR 등
+  is_adult_content: boolean; // 18등급 여부 (블러 효과용)
   created_at?: string;
   __v?: number;
   rank?: number;


### PR DESCRIPTION
# [Fix] 메인 페이지 로딩 로직 개선 및 에러 처리 추가

## 개요
- `useMovies` 훅에서 `error` 상태를 가져오도록 수정  
- 영화 데이터 로드 로직을 하나의 `useEffect`로 통합  
- 개발 환경에서 카테고리 변경 시 디버깅 로그 출력 추가  

## 설명
### What
- `WatchaMainPage`에서 `useMovies` 훅 사용 시 `error` 상태를 추가 관리  
- 초기 로드 및 카테고리 변경 시 데이터를 불러오는 `useEffect` 로직을 하나로 통합  
- `NODE_ENV=development` 환경에서 카테고리 변경 시 `console.log`로 디버깅 로그 추가  

### Why
- 에러 발생 시 대응할 수 있도록 상태 관리 확장  
- 중복된 `useEffect` 제거로 코드 가독성과 유지보수성 개선  
- 개발 환경에서 데이터 로드 흐름을 확인할 수 있도록 가시성 강화  

### How
- `useMovies` 훅 구조 분해에 `error` 추가  
- 두 개의 `useEffect` → 하나로 통합  
- 조건부 `console.log` 추가  

## 참고 (optional)
- 관련 이슈 번호: 없음  
- 테스트: 카테고리 변경 및 초기 로드 시 정상적으로 영화 데이터 로딩 및 에러 상태 확인 가능 