### PR TITLE
Refactor :UI Change

### DIFF
--- a/src/app/(public)/login/page.tsx
+++ b/src/app/(public)/login/page.tsx
@@ -1,0 +1,5 @@
+import LoginForm from '@/components/forms/LoginForm';
+
+export default function LoginPage() {
+  return <LoginForm />;
+}

--- a/src/app/(public)/register/page.tsx
+++ b/src/app/(public)/register/page.tsx
@@ -1,0 +1,5 @@
+import RegisterForm from '@/components/forms/RegisterForm';
+
+export default function LoginPage() {
+  return <RegisterForm />;
+}

--- a/src/components/common/NavigationBar/NavigationBar.tsx
+++ b/src/components/common/NavigationBar/NavigationBar.tsx
@@ -4,6 +4,7 @@
 import React, { useState } from 'react';
 import { watchaTokens } from '@/styles/tokens';
 import { NavigationBarProps } from '@/types/navigationBar';
+import { useRouter } from 'next/navigation';
 
 export const NavigationBar: React.FC<NavigationBarProps> = ({
   activeMenu = '홈',
@@ -107,6 +108,8 @@ export const NavigationBar: React.FC<NavigationBarProps> = ({
     }
   };
 
+  const router = useRouter();
+
   return (
     <nav style={navStyle}>
       <div style={containerStyle}>
@@ -158,6 +161,7 @@ export const NavigationBar: React.FC<NavigationBarProps> = ({
           onMouseLeave={(e) => {
             (e.target as HTMLElement).style.background = watchaTokens.colors.primary;
           }}
+          onClick={() => router.push('/login')}
         >
           회원가입/로그인
         </button>

--- a/src/components/forms/LoginForm.tsx
+++ b/src/components/forms/LoginForm.tsx
@@ -1,0 +1,205 @@
+'use client';
+import { useState } from 'react';
+import Image from 'next/image';
+import Link from 'next/link';
+import axios from 'axios';
+import { Button } from '@/components/common/Button';
+
+const LoginForm = () => {
+  const [formData, setFormData] = useState({
+    email: '',
+    password: '',
+  });
+  const [showPassword, setShowPassword] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
+    setFormData((prev) => ({
+      ...prev,
+      [name]: value,
+    }));
+    if (error) setError('');
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setLoading(true);
+    setError('');
+
+    try {
+      const response = await axios.post('/api/auth/login', formData);
+
+      if (response.data.success) {
+        localStorage.setItem('token', response.data.data.token);
+        // 로그인 성공 처리 (예: 페이지 리다이렉트 등)
+        console.log('로그인 성공:', response.data.data);
+        // router.push('/dashboard'); // next/navigation 사용 시
+      }
+    } catch (error: any) {
+      setError(error.response?.data?.message || '네트워크 오류가 발생했습니다.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleOAuthLogin = (provider: string) => {
+    window.location.href = `/api/auth/${provider}`;
+  };
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-gray-900 via-gray-800 to-black flex items-center justify-center p-4">
+      <div className="bg-white/95 backdrop-blur-lg rounded-2xl shadow-2xl border border-gray-200/50 w-full max-w-md p-8">
+        <div className="text-center mb-8">
+          <div className="bg-gradient-to-r from-pink-500 to-red-500 w-16 h-16 rounded-full flex items-center justify-center mx-auto mb-4">
+            <Image src="/auth/exit.png" alt="Login" className="w-8 h-8" width={32} height={32} />
+          </div>
+          <h2 className="text-3xl font-bold text-gray-900 mb-2">로그인</h2>
+          <p className="text-gray-600 mt-2">계정에 로그인하세요</p>
+        </div>
+
+        {error && (
+          <div className="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded-lg mb-6">
+            {error}
+          </div>
+        )}
+
+        <form onSubmit={handleSubmit} className="space-y-6">
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-2">이메일</label>
+            <div className="relative">
+              <Image
+                src="/auth/mail.png"
+                alt="Mail"
+                className="absolute left-3 top-1/2 transform -translate-y-1/2 w-5 h-5"
+                width={20}
+                height={20}
+              />
+              <input
+                type="email"
+                name="email"
+                value={formData.email}
+                onChange={handleChange}
+                className="w-full pl-11 pr-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-pink-500 focus:border-pink-500 transition-all duration-200 text-gray-900 placeholder-gray-500"
+                placeholder="이메일을 입력하세요"
+                required
+              />
+            </div>
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-2">비밀번호</label>
+            <div className="relative">
+              <Image
+                src="/auth/lock.png"
+                alt="lock"
+                className="absolute left-3 top-1/2 transform -translate-y-1/2 w-5 h-5"
+                width={20}
+                height={20}
+              />
+              <input
+                type={showPassword ? 'text' : 'password'}
+                name="password"
+                value={formData.password}
+                onChange={handleChange}
+                className="w-full pl-11 pr-12 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-pink-500 focus:border-pink-500 transition-all duration-200 text-gray-900 placeholder-gray-500"
+                placeholder="비밀번호를 입력하세요"
+                required
+              />
+              <button
+                type="button"
+                onClick={() => setShowPassword(!showPassword)}
+                className="absolute right-3 top-1/2 transform -translate-y-1/2 text-gray-400 hover:text-pink-500 transition-colors"
+              >
+                <Image
+                  src={showPassword ? '/auth/open-eye.png' : '/auth/close-eye.png'}
+                  alt="Toggle Password"
+                  className="w-5 h-5"
+                  width={20}
+                  height={20}
+                />
+              </button>
+            </div>
+          </div>
+
+          <div className="flex items-center justify-between">
+            <Link
+              href="/forgot-password"
+              className="text-sm text-pink-600 hover:text-pink-700 font-medium transition-colors duration-200"
+            >
+              비밀번호를 잊으셨나요?
+            </Link>
+          </div>
+
+          <Button
+            type="submit"
+            disabled={loading}
+            variant="primary"
+            size="lg"
+            fullWidth
+            className="bg-gradient-to-r from-pink-500 to-red-500 hover:from-pink-600 hover:to-red-600 focus:ring-pink-500 transform hover:scale-[1.02] shadow-lg"
+          >
+            {loading ? '로그인 중...' : '로그인'}
+          </Button>
+        </form>
+
+        <div className="mt-6">
+          <div className="relative">
+            <div className="absolute inset-0 flex items-center">
+              <div className="w-full border-t border-gray-300" />
+            </div>
+            <div className="relative flex justify-center text-sm">
+              <span className="px-2 text-gray-500">또는</span>
+            </div>
+          </div>
+
+          <div className="mt-6 grid grid-cols-2 gap-3">
+            <Button
+              onClick={() => handleOAuthLogin('google')}
+              variant="secondary"
+              size="md"
+              className="justify-center items-center bg-white border-gray-300 text-gray-700 hover:bg-gray-50 hover:border-pink-500 hover:text-pink-600"
+            >
+              <Image
+                src="/auth/google.png"
+                alt="Google"
+                className="w-5 h-5 mr-2"
+                width={20}
+                height={20}
+              />
+            </Button>
+            <Button
+              onClick={() => handleOAuthLogin('github')}
+              variant="secondary"
+              size="md"
+              className="justify-center items-center bg-white border-gray-300 text-gray-700 hover:bg-gray-50"
+            >
+              <Image
+                src="/auth/github.png"
+                alt="GitHub"
+                className="w-5 h-5 mr-2"
+                width={20}
+                height={20}
+              />
+            </Button>
+          </div>
+        </div>
+
+        <div className="mt-8 text-center">
+          <p className="text-sm text-gray-600">
+            계정이 없으신가요?{' '}
+            <Link
+              href="/register"
+              className="font-semibold text-pink-600 hover:text-pink-700 transition-colors duration-200"
+            >
+              회원가입
+            </Link>
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default LoginForm;

--- a/src/components/forms/RegisterForm.tsx
+++ b/src/components/forms/RegisterForm.tsx
@@ -1,0 +1,337 @@
+'use client';
+import { useState } from 'react';
+import Image from 'next/image';
+import Link from 'next/link';
+import axios from 'axios';
+import { Button } from '@/components/common/Button';
+
+const RegisterForm = () => {
+  const [formData, setFormData] = useState({
+    username: '',
+    email: '',
+    password: '',
+    confirmPassword: '',
+    nickname: '',
+  });
+  const [showPassword, setShowPassword] = useState(false);
+  const [showConfirmPassword, setShowConfirmPassword] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
+    setFormData((prev) => ({
+      ...prev,
+      [name]: value,
+    }));
+    if (error) setError('');
+  };
+
+  const validatePassword = (password: string): string | null => {
+    if (password.length < 8) {
+      return '비밀번호는 최소 8자 이상이어야 합니다.';
+    }
+    if (!/(?=.*[a-z])/.test(password)) {
+      return '비밀번호는 소문자를 포함해야 합니다.';
+    }
+    if (!/(?=.*[A-Z])/.test(password)) {
+      return '비밀번호는 대문자를 포함해야 합니다.';
+    }
+    if (!/(?=.*\d)/.test(password)) {
+      return '비밀번호는 숫자를 포함해야 합니다.';
+    }
+    return null;
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setLoading(true);
+    setError('');
+
+    // 비밀번호 확인
+    if (formData.password !== formData.confirmPassword) {
+      setError('비밀번호가 일치하지 않습니다.');
+      setLoading(false);
+      return;
+    }
+
+    // 비밀번호 강도 검사
+    const passwordError = validatePassword(formData.password);
+    if (passwordError) {
+      setError(passwordError);
+      setLoading(false);
+      return;
+    }
+
+    try {
+      const { confirmPassword, ...registerData } = formData;
+      const response = await axios.post('/api/auth/register', registerData);
+
+      if (response.data.success) {
+        localStorage.setItem('token', response.data.data.token);
+        // 회원가입 성공 처리 (예: 페이지 리다이렉트 등)
+        console.log('회원가입 성공:', response.data.data);
+        // router.push('/dashboard'); // next/navigation 사용 시
+      }
+    } catch (error: any) {
+      setError(error.response?.data?.message || '네트워크 오류가 발생했습니다.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleOAuthRegister = (provider: string) => {
+    window.location.href = `/api/auth/${provider}`;
+  };
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-gray-900 via-gray-800 to-black flex items-center justify-center p-4">
+      <div className="bg-white/95 backdrop-blur-lg rounded-2xl shadow-2xl border border-gray-200/50 w-full max-w-md p-8">
+        <div className="text-center mb-8">
+          <div className="bg-gradient-to-r from-pink-500 to-red-500 w-16 h-16 rounded-full flex items-center justify-center mx-auto mb-4">
+            <Image
+              src="/auth/register.png"
+              alt="Register"
+              className="w-8 h-8"
+              width={32}
+              height={32}
+            />
+          </div>
+          <h2 className="text-3xl font-bold text-gray-900 mb-2">회원가입</h2>
+          <p className="text-gray-600 mt-2">새 계정을 만드세요</p>
+        </div>
+
+        {error && (
+          <div className="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded-lg mb-6">
+            {error}
+          </div>
+        )}
+
+        <form onSubmit={handleSubmit} className="space-y-5">
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-2">사용자명</label>
+            <div className="relative">
+              <Image
+                src="/auth/user.png"
+                alt="User"
+                className="absolute left-3 top-1/2 transform -translate-y-1/2 w-5 h-5"
+                width={20}
+                height={20}
+              />
+              <input
+                type="text"
+                name="username"
+                value={formData.username}
+                onChange={handleChange}
+                className="w-full pl-11 pr-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-pink-500 focus:border-pink-500 transition-all duration-200 text-gray-900 placeholder-gray-500"
+                placeholder="사용자명을 입력하세요"
+                required
+              />
+            </div>
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-2">닉네임</label>
+            <div className="relative">
+              <Image
+                src="/auth/user.png"
+                alt="User"
+                className="absolute left-3 top-1/2 transform -translate-y-1/2 w-5 h-5"
+                width={20}
+                height={20}
+              />
+              <input
+                type="text"
+                name="nickname"
+                value={formData.nickname}
+                onChange={handleChange}
+                className="w-full pl-11 pr-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-pink-500 focus:border-pink-500 transition-all duration-200 text-gray-900 placeholder-gray-500"
+                placeholder="닉네임을 입력하세요"
+                required
+              />
+            </div>
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-2">이메일</label>
+            <div className="relative">
+              <Image
+                src="/auth/mail.png"
+                alt="Mail"
+                className="absolute left-3 top-1/2 transform -translate-y-1/2 w-5 h-5"
+                width={20}
+                height={20}
+              />
+              <input
+                type="email"
+                name="email"
+                value={formData.email}
+                onChange={handleChange}
+                className="w-full pl-11 pr-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-pink-500 focus:border-pink-500 transition-all duration-200 text-gray-900 placeholder-gray-500"
+                placeholder="이메일을 입력하세요"
+                required
+              />
+            </div>
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-2">비밀번호</label>
+            <div className="relative">
+              <Image
+                src="/auth/lock.png"
+                alt="Lock"
+                className="absolute left-3 top-1/2 transform -translate-y-1/2 w-5 h-5"
+                width={20}
+                height={20}
+              />
+              <input
+                type={showPassword ? 'text' : 'password'}
+                name="password"
+                value={formData.password}
+                onChange={handleChange}
+                className="w-full pl-11 pr-12 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-pink-500 focus:border-pink-500 transition-all duration-200 text-gray-900 placeholder-gray-500"
+                placeholder="비밀번호를 입력하세요"
+                required
+              />
+              <button
+                type="button"
+                onClick={() => setShowPassword(!showPassword)}
+                className="absolute right-3 top-1/2 transform -translate-y-1/2 text-gray-400 hover:text-pink-500 transition-colors"
+              >
+                <Image
+                  src={showPassword ? '/auth/open-eye.png' : '/auth/close-eye.png'}
+                  alt="Toggle Password"
+                  className="w-5 h-5"
+                  width={20}
+                  height={20}
+                />
+              </button>
+            </div>
+            <p className="text-xs text-gray-500 mt-1">대소문자, 숫자를 포함하여 8자 이상</p>
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-2">비밀번호 확인</label>
+            <div className="relative">
+              <Image
+                src="/auth/lock.png"
+                alt="Lock"
+                className="absolute left-3 top-1/2 transform -translate-y-1/2 w-5 h-5"
+                width={20}
+                height={20}
+              />
+              <input
+                type={showConfirmPassword ? 'text' : 'password'}
+                name="confirmPassword"
+                value={formData.confirmPassword}
+                onChange={handleChange}
+                className="w-full pl-11 pr-12 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-pink-500 focus:border-pink-500 transition-all duration-200 text-gray-900 placeholder-gray-500"
+                placeholder="비밀번호를 다시 입력하세요"
+                required
+              />
+              <button
+                type="button"
+                onClick={() => setShowConfirmPassword(!showConfirmPassword)}
+                className="absolute right-3 top-1/2 transform -translate-y-1/2 text-gray-400 hover:text-pink-500 transition-colors"
+              >
+                <Image
+                  src={showConfirmPassword ? '/auth/open-eye.png' : '/auth/close-eye.png'}
+                  alt="Toggle Password"
+                  className="w-5 h-5"
+                  width={20}
+                  height={20}
+                />
+              </button>
+            </div>
+          </div>
+
+          <div className="flex items-center">
+            <input
+              id="terms"
+              type="checkbox"
+              className="h-4 w-4 text-pink-600 focus:ring-pink-500 border-gray-300 rounded"
+              required
+            />
+            <label htmlFor="terms" className="ml-2 block text-sm text-gray-700">
+              <Link href="/terms" className="text-pink-600 hover:text-pink-700">
+                이용약관
+              </Link>
+              과{' '}
+              <Link href="/privacy" className="text-pink-600 hover:text-pink-700">
+                개인정보처리방침
+              </Link>
+              에 동의합니다
+            </label>
+          </div>
+
+          <Button
+            type="submit"
+            disabled={loading}
+            variant="primary"
+            size="lg"
+            fullWidth
+            className="bg-gradient-to-r from-pink-500 to-red-500 hover:from-pink-600 hover:to-red-600 focus:ring-pink-500 transform hover:scale-[1.02] shadow-lg"
+          >
+            {loading ? '가입 중...' : '회원가입'}
+          </Button>
+        </form>
+
+        <div className="mt-6">
+          <div className="relative">
+            <div className="absolute inset-0 flex items-center">
+              <div className="w-full border-t border-gray-300" />
+            </div>
+            <div className="relative flex justify-center text-sm">
+              <span className="px-2 text-gray-500">또는</span>
+            </div>
+          </div>
+
+          <div className="mt-6 grid grid-cols-2 gap-3">
+            <Button
+              onClick={() => handleOAuthRegister('google')}
+              variant="secondary"
+              size="md"
+              className="justify-center items-center bg-white border-gray-300 text-gray-700 hover:bg-gray-50 hover:border-pink-500 hover:text-pink-600"
+            >
+              <Image
+                src="/auth/google.png"
+                alt="Google"
+                className="w-5 h-5 mr-2"
+                width={20}
+                height={20}
+              />
+            </Button>
+            <Button
+              onClick={() => handleOAuthRegister('github')}
+              variant="secondary"
+              size="md"
+              className="justify-center items-center bg-white border-gray-300 text-gray-700 hover:bg-gray-50"
+            >
+              <Image
+                src="/auth/github.png"
+                alt="GitHub"
+                className="w-5 h-5 mr-2"
+                width={20}
+                height={20}
+              />
+            </Button>
+          </div>
+        </div>
+
+        <div className="mt-8 text-center">
+          <p className="text-sm text-gray-600">
+            이미 계정이 있으신가요?{' '}
+            <Link
+              href="/login"
+              className="font-semibold text-pink-600 hover:text-pink-700 transition-colors duration-200"
+            >
+              로그인
+            </Link>
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default RegisterForm;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -7,17 +7,32 @@ const config: Config = {
     extend: {
       colors: {
         primary: {
-          DEFAULT: '#ff0558',
+          DEFAULT: '#ff0558', // Watcha Pink
           dark: '#e6004f',
+          light: '#ff4081',
+        },
+        secondary: {
+          DEFAULT: '#141517', // Watcha Dark
+          light: '#2a2d32',
         },
         surface: {
           DEFAULT: '#f8f9fa',
           hover: '#e9ecef',
+          dark: '#1a1d23',
         },
         danger: {
           DEFAULT: '#ef4444',
           dark: '#dc2626',
           hover: '#dc2626',
+        },
+        watcha: {
+          pink: '#ff0558',
+          'pink-dark': '#e6004f',
+          'pink-light': '#ff4081',
+          dark: '#141517',
+          'dark-light': '#2a2d32',
+          gray: '#6b7280',
+          'gray-light': '#9ca3af',
         },
       },
       fontFamily: {
@@ -39,6 +54,7 @@ const config: Config = {
       boxShadow: {
         primary: '0 4px 12px rgba(255, 5, 88, 0.3)',
         danger: '0 4px 12px rgba(239, 68, 68, 0.3)',
+        watcha: '0 4px 20px rgba(255, 5, 88, 0.25)',
       },
       animation: {
         'spin-smooth': 'spin 1s linear infinite',
@@ -54,7 +70,7 @@ const config: Config = {
           alignItems: 'center',
           justifyContent: 'center',
           fontFamily: theme('fontFamily.sans'),
-          fontWeight: '500',
+          fontWeight: '600', // Watcha는 조금 더 볼드
           cursor: 'pointer',
           transition: 'all 0.2s ease',
           userSelect: 'none',
@@ -76,43 +92,47 @@ const config: Config = {
           },
         },
 
-        // Button Variants
+        // Button Variants - Watcha Style
         '.btn-primary': {
-          backgroundColor: theme('colors.primary.DEFAULT'),
+          backgroundColor: theme('colors.watcha.pink'),
           color: 'white',
           border: 'none',
 
           '&:not(:disabled):hover': {
-            backgroundColor: theme('colors.primary.dark'),
-            boxShadow: theme('boxShadow.primary'),
+            backgroundColor: theme('colors.watcha.pink-dark'),
+            boxShadow: theme('boxShadow.watcha'),
           },
 
           '&:not(:disabled):active': {
-            backgroundColor: theme('colors.primary.dark'),
+            backgroundColor: theme('colors.watcha.pink-dark'),
           },
         },
 
         '.btn-secondary': {
           backgroundColor: 'transparent',
-          color: theme('colors.primary.DEFAULT'),
-          border: `2px solid ${theme('colors.primary.DEFAULT')}`,
+          color: theme('colors.watcha.pink'),
+          border: `2px solid ${theme('colors.watcha.pink')}`,
 
           '&:not(:disabled):hover': {
-            backgroundColor: theme('colors.surface.hover'),
+            backgroundColor: theme('colors.watcha.pink'),
+            color: 'white',
           },
 
           '&:not(:disabled):active': {
-            backgroundColor: theme('colors.surface.DEFAULT'),
+            backgroundColor: theme('colors.watcha.pink-dark'),
+            color: 'white',
           },
         },
 
         '.btn-ghost': {
           backgroundColor: 'transparent',
-          color: theme('colors.gray.900'),
+          color: theme('colors.watcha.dark'),
           border: `1px solid ${theme('colors.gray.300')}`,
 
           '&:not(:disabled):hover': {
             backgroundColor: theme('colors.surface.hover'),
+            borderColor: theme('colors.watcha.pink'),
+            color: theme('colors.watcha.pink'),
           },
 
           '&:not(:disabled):active': {
@@ -122,12 +142,12 @@ const config: Config = {
 
         '.btn-text': {
           backgroundColor: 'transparent',
-          color: theme('colors.gray.600'),
+          color: theme('colors.watcha.gray'),
           border: 'none',
 
           '&:not(:disabled):hover': {
             backgroundColor: theme('colors.surface.hover'),
-            color: theme('colors.gray.900'),
+            color: theme('colors.watcha.pink'),
           },
 
           '&:not(:disabled):active': {


### PR DESCRIPTION
[FEAT] 로그인/회원가입 페이지 및 Watcha 브랜드 컬러 시스템 구현

## 개요
- 사용자 인증을 위한 로그인/회원가입 페이지를 새로 구현했습니다
- Watcha 브랜드 아이덴티티에 맞는 핑크 계열 컬러 시스템을 도입했습니다
- 네비게이션 바에서 로그인 페이지로의 라우팅 기능을 추가했습니다

## 설명

### What
- **새로운 페이지**: `/login`, `/register` 라우트 및 폼 컴포넌트 추가
- **디자인 시스템**: Watcha 브랜드 컬러를 반영한 Tailwind 설정 업데이트
- **네비게이션**: 메인 네비게이션 바에서 로그인 페이지 연결
- **폼 기능**: 이메일/비밀번호 로그인, OAuth(Google/GitHub), 비밀번호 강도 검증

### Why
- 사용자 인증 시스템 구축을 위한 UI 기반 작업이 필요했습니다
- 기존 보라색 계열 컬러가 Watcha 브랜드와 맞지 않아 일관성 있는 디자인 시스템이 필요했습니다
- 사용자가 직관적으로 회원가입/로그인에 접근할 수 있는 경로가 필요했습니다

### How

**🎨 컬러 시스템 개선**
```
watcha: {
 pink: '#ff0558',        // 메인 브랜드 컬러
 'pink-dark': '#e6004f', // 호버/액티브 상태
 'pink-light': '#ff4081', // 보조 컬러
 dark: '#141517',        // Watcha 다크 톤
}

```

**🔐 인증 폼 구현**
- `LoginForm`: 이메일/비밀번호 로그인, OAuth 지원, 에러 처리
- `RegisterForm`: 회원가입 폼, 비밀번호 강도 검증, 약관 동의
- 반응형 디자인 및 접근성 고려한 UI/UX

**🎯 Button 컴포넌트 업데이트**
- Primary 버튼: Watcha 핑크 그라데이션
- Secondary 버튼: 투명 배경 → 핑크 배경 호버 효과
- Ghost/Text 버튼: 호버 시 핑크 컬러 강조

**🚀 라우팅 연결**
- NavigationBar에서 로그인 버튼 클릭 시 `/login` 페이지로 이동
- 로그인 ↔ 회원가입 페이지 간 상호 링크 연결

## 참고
- 🖼️ 아이콘 이미지는 `/public/auth/` 경로에 위치 필요 (mail.png, lock.png, user.png 등)
- 🔑 실제 인증 API 연동은 별도 작업 필요
- 📱 모바일 반응형 디자인 적용 완료
- ♿ 접근성 고려한 라벨링 및 키보드 네비게이션 지원